### PR TITLE
Include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+graft tests


### PR DESCRIPTION
This commit adds the tests subfolder to the sdist, so that it can be run, when creating the corresponding package for Fedora.

Would it also be possible to add a license file, so it is clear, which license ptyprocess has?
