### PR TITLE
Use readline to read full output of closing parent process

### DIFF
--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -15,7 +15,7 @@ class PtyTestCase(unittest.TestCase):
         assert b'rebar' in response
         
         p.sendeof()
-        p.read()
+        p.readline()
         
         with self.assertRaises(EOFError):
             p.read()
@@ -31,7 +31,7 @@ class PtyTestCase(unittest.TestCase):
         assert u'rebar' in response
         
         p.sendeof()
-        p.read()
+        p.readline()
         
         with self.assertRaises(EOFError):
             p.read()


### PR DESCRIPTION
This fixes the seen race conditions in #7. 

Thanks for helping tracking it down.