### PR TITLE
Added screen size parameters.

### DIFF
--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -172,15 +172,20 @@ class PtyProcess(object):
         self.delayafterterminate = 0.1
 
     @classmethod
-    def spawn(cls, argv, cwd=None, env=None, echo=True, preexec_fn=None):
+    def spawn(
+            cls, argv, cwd=None, env=None, echo=True, preexec_fn=None,
+            dimensions=(24, 80)):
         '''Start the given command in a child process in a pseudo terminal.
-        
+
         This does all the fork/exec type of stuff for a pty, and returns an
         instance of PtyProcess.
 
         If preexec_fn is supplied, it will be called with no arguments in the
         child process before exec-ing the specified command.
         It may, for instance, set signal handlers to SIG_DFL or SIG_IGN.
+
+        Dimensions of the psuedoterminal used for the subprocess can be
+        specified as a tuple, or the default (24, 80) will be used.
         '''
         # Note that it is difficult for this method to fail.
         # You cannot detect if the child process cannot start.
@@ -224,9 +229,9 @@ class PtyProcess(object):
         # allowing IOError for either.
 
         if pid == CHILD:
-            # set default window size of 24 rows by 80 columns
+            # set window size
             try:
-                _setwinsize(STDIN_FILENO, 24, 80)
+                _setwinsize(STDIN_FILENO, *dimensions)
             except IOError as err:
                 if err.args[0] not in (errno.EINVAL, errno.ENOTTY):
                     raise

--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -323,7 +323,7 @@ class PtyProcess(object):
                 raise exception
 
         try:
-            inst.setwinsize(24, 80)
+            inst.setwinsize(*dimensions)
         except IOError as err:
             if err.args[0] not in (errno.EINVAL, errno.ENOTTY):
                 raise

--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -185,7 +185,7 @@ class PtyProcess(object):
         It may, for instance, set signal handlers to SIG_DFL or SIG_IGN.
 
         Dimensions of the psuedoterminal used for the subprocess can be
-        specified as a tuple, or the default (24, 80) will be used.
+        specified as a tuple (rows, cols), or the default (24, 80) will be used.
         '''
         # Note that it is difficult for this method to fail.
         # You cannot detect if the child process cannot start.


### PR DESCRIPTION
I found myself wanting to set the size of the `pty` as seen by the subprocess (really for `pexpect.spawn`, but this is needed first). In some situations it can make parsing/interaction a lot easier.

Happy to change any stylistic things, eg.

  1. The `dimensions=(24, 80)` default arg could also be `dimensions=None` with some `if dimensions is not None` logic in `spawn()`.
  2. It could be `r=24, c=80` instead, but does it make sense to only have *one* dimension with a default? (Maybe, I don't know.)

I meant to add a test, but couldn't figure out a simple enough way to test this (eg. if there was a reliable command to check console size it could be like the other `spawn` tests, but I don't know of one).