### PR TITLE
wait(): return exit status instead of raising an exception

### DIFF
--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -653,7 +653,7 @@ class PtyProcess(object):
         if self.isalive():
             pid, status = os.waitpid(self.pid, 0)
         else:
-            raise PtyProcessError('Cannot wait for dead child process.')
+            return self.exitstatus
         self.exitstatus = os.WEXITSTATUS(status)
         if os.WIFEXITED(status):
             self.status = status

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+'''
+PEXPECT LICENSE
+
+    This license is approved by the OSI and FSF as GPL-compatible.
+        http://opensource.org/licenses/isc-license.txt
+
+    Copyright (c) 2012, Noah Spurrier <noah@noah.org>
+    PERMISSION TO USE, COPY, MODIFY, AND/OR DISTRIBUTE THIS SOFTWARE FOR ANY
+    PURPOSE WITH OR WITHOUT FEE IS HEREBY GRANTED, PROVIDED THAT THE ABOVE
+    COPYRIGHT NOTICE AND THIS PERMISSION NOTICE APPEAR IN ALL COPIES.
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+'''
+import time
+import unittest
+from ptyprocess import PtyProcess
+
+class WaitOnTerminated(unittest.TestCase):
+
+    def test_wait_true(self):
+        child = PtyProcess.spawn(['/bin/true'])
+        # Wait so we're reasonable sure /bin/true has terminated
+        time.sleep(0.2)
+        exitstatus = child.wait()
+        assert exitstatus == 0
+
+    def test_wait_false(self):
+        child = PtyProcess.spawn(['/bin/false'])
+        time.sleep(0.2)
+        exitstatus = child.wait()
+        assert exitstatus == 1
+
+if __name__ == '__main__':
+    unittest.main()
+
+suite = unittest.makeSuite(WaitOnTerminated,'test')


### PR DESCRIPTION
Fixes #13. I thought the fix would be more complicated, but it seems isalive() will set all the needed fields if the child has terminated.

I am not familiar with the unit testing framework, so the test may not be very idiomatic.