### PR TITLE
Solaris 11, python2.6 fixes in ptyprocess.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ python:
 before_script: pip install -rrequirements-testing.txt
 # command to run tests
 script: py.test
+
+# faster builds on travis-ci
+sudo: False

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+before_script: pip install -rrequirements-testing.txt
 # command to run tests
 script: py.test

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ copyright = u'2014, Thomas Kluyver'
 # built documents.
 #
 # The short X.Y version.
-version = '0.4'
+version = '0.5'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,0 +1,3 @@
+# unittest2 is a backport of the new features in Python 2.7 and onwards.
+# we use this for python2.6, such as "with self.assertRaises(..)"
+unittest2

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as f:
     readme = f.read()
 
 setup(name='ptyprocess',
-      version='0.4',
+      version='0.5',
       description="Run a subprocess in a pseudo terminal",
       long_description=readme,
       author='Thomas Kluyver',

--- a/tests/test_invalid_binary.py
+++ b/tests/test_invalid_binary.py
@@ -19,14 +19,14 @@ PEXPECT LICENSE
 
 '''
 import time
-import unittest
+import unittest, unittest2
 from ptyprocess import PtyProcess, PtyProcessUnicode
 import errno
 import os
 import stat
 import tempfile
 
-class InvalidBinaryChars(unittest.TestCase):
+class InvalidBinaryChars(unittest2.TestCase):
 
     def test_invalid_binary(self):
         '''This tests that we correctly handle the case where we attempt to
@@ -67,8 +67,8 @@ class InvalidBinaryChars(unittest.TestCase):
             os.unlink(fullpath)
             os.rmdir(dirpath)
 
+
 if __name__ == '__main__':
     unittest.main()
 
 suite = unittest.makeSuite(InvalidBinaryChars,'test')
-

--- a/tests/test_preexec_fn.py
+++ b/tests/test_preexec_fn.py
@@ -18,13 +18,21 @@ PEXPECT LICENSE
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 '''
-import unittest
+import unittest, unittest2
 import shutil
 from ptyprocess import PtyProcess
 import os
 import tempfile
 
-class PreexecFns(unittest.TestCase):
+class PreexecFns(unittest2.TestCase):
+    def setUp(self):
+        self.pid = os.getpid()
+
+    def tearDown(self):
+        if self.pid != os.getpid():
+            sys.stderr.write('\nERROR: Test runner has forked! Exiting!\n')
+            os._exit(1)
+
     def test_preexec(self):
         td = tempfile.mkdtemp()
         filepath = os.path.join(td, 'foo')
@@ -56,3 +64,7 @@ class PreexecFns(unittest.TestCase):
                 raise
 
 
+if __name__ == '__main__':
+    unittest.main()
+
+suite = unittest.makeSuite(PreexecFns, 'test')

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -1,9 +1,10 @@
+#!/usr/bin/env python
 import os
 import time
-import unittest
+import unittest, unittest2
 from ptyprocess import PtyProcess, PtyProcessUnicode
 
-class PtyTestCase(unittest.TestCase):
+class PtyTestCase(unittest2.TestCase):
     def test_spawn_sh(self):
         env = os.environ.copy()
         env['FOO'] = 'rebar'
@@ -35,3 +36,15 @@ class PtyTestCase(unittest.TestCase):
         
         with self.assertRaises(EOFError):
             p.read()
+
+    def test_quick_spawn(self):
+        """Spawn a very short-lived process."""
+        # so far only reproducable on Solaris 11, spawning a process
+        # that exits very quickly raised an exception at 'inst.setwinsize',
+        # because the pty filedes was quickly lost after exec().
+        PtyProcess.spawn(['/bin/true'])
+
+if __name__ == '__main__':
+    unittest.main()
+
+suite = unittest.makeSuite(PtyTestCase, 'test')


### PR DESCRIPTION
- ``termios.tcgetattr(fd)[6][VEOF]`` becomes value of ``1``(int), where we expect ``'\x04'`` (^D).  seems to be a bug with the compilation of python2.6 that Sun provides with Solaris 11. This raises TypeError when ``ord(1)`` happens when trying to determine the byte for EOF.

  If ``_is_solaris`` is True, and the return value is an integer, just assume its a bork and manually set ``eof = 4``(int)(^D).

- Fix several "ValueError: zero length field name in format" errors for Python 2.6, which is what ships with Solaris 11.  This caused an exception at a critical path in pty.fork(), where the parent would block on os.read of 'exec_err_pipe_read' indefinitely, as the child raised an exception trying to construct the 'tosend' value (though the exception could not be seen). Test runner just blocks indefinitely without such fixes.

- In spawn(), allow ``errno.ENXIO`` when calling ``inst.setwindowsize()``, in some cases, such as ``spawn(['/bin/true'])``, the child process may have exited so quickly as to no longer be able to accept any terminal driver calls. Reported by @reynir in https://github.com/pexpect/pexpect/issues/206