### PR TITLE
Ignore errno.ENXIO in inst.setwinsize after fork

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ copyright = u'2014, Thomas Kluyver'
 # built documents.
 #
 # The short X.Y version.
-version = '0.4'
+version = '0.5'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -325,7 +325,7 @@ class PtyProcess(object):
         try:
             inst.setwinsize(*dimensions)
         except IOError as err:
-            if err.args[0] not in (errno.EINVAL, errno.ENOTTY):
+            if err.args[0] not in (errno.EINVAL, errno.ENOTTY, errno.ENXIO):
                 raise
 
         return inst

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as f:
     readme = f.read()
 
 setup(name='ptyprocess',
-      version='0.4',
+      version='0.5',
       description="Run a subprocess in a pseudo terminal",
       long_description=readme,
       author='Thomas Kluyver',

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -40,5 +40,5 @@ class PtyTestCase(unittest.TestCase):
         """Spawn a very short-lived process."""
         # so far only reproducable on Solaris 11, spawning a process
         # that exits very quickly raised an exception at 'inst.setwinsize',
-        # because the pty filedes was quickly lost after exec().
+        # because the pty file descriptor was quickly lost after exec().
         PtyProcess.spawn(['/bin/true'])

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -1,10 +1,9 @@
-#!/usr/bin/env python
 import os
 import time
-import unittest, unittest2
+import unittest
 from ptyprocess import PtyProcess, PtyProcessUnicode
 
-class PtyTestCase(unittest2.TestCase):
+class PtyTestCase(unittest.TestCase):
     def test_spawn_sh(self):
         env = os.environ.copy()
         env['FOO'] = 'rebar'
@@ -43,8 +42,3 @@ class PtyTestCase(unittest2.TestCase):
         # that exits very quickly raised an exception at 'inst.setwinsize',
         # because the pty filedes was quickly lost after exec().
         PtyProcess.spawn(['/bin/true'])
-
-if __name__ == '__main__':
-    unittest.main()
-
-suite = unittest.makeSuite(PtyTestCase, 'test')

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -1,9 +1,10 @@
+#!/usr/bin/env python
 import os
 import time
-import unittest
+import unittest, unittest2
 from ptyprocess import PtyProcess, PtyProcessUnicode
 
-class PtyTestCase(unittest.TestCase):
+class PtyTestCase(unittest2.TestCase):
     def test_spawn_sh(self):
         env = os.environ.copy()
         env['FOO'] = 'rebar'
@@ -35,3 +36,15 @@ class PtyTestCase(unittest.TestCase):
         
         with self.assertRaises(EOFError):
             p.read()
+
+    def test_quick_spawn(self):
+        """Spawn a very short-lived process."""
+        # so far only reproducable on Solaris 11, spawning a process
+        # that exits very quickly raised an exception at 'inst.setwinsize',
+        # because the pty filedes was quickly lost after exec().
+        PtyProcess.spawn(['/bin/true'])
+
+if __name__ == '__main__':
+    unittest.main()
+
+suite = unittest.makeSuite(PtyTestCase, 'test')


### PR DESCRIPTION
From bug reported in pexpect, https://github.com/pexpect/pexpect/issues/206