### PR TITLE
wait(): return exit status instead of raising an exception

### DIFF
--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -653,7 +653,7 @@ class PtyProcess(object):
         if self.isalive():
             pid, status = os.waitpid(self.pid, 0)
         else:
-            raise PtyProcessError('Cannot wait for dead child process.')
+            return self.exitstatus
         self.exitstatus = os.WEXITSTATUS(status)
         if os.WIFEXITED(status):
             self.status = status

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+'''
+PEXPECT LICENSE
+
+    This license is approved by the OSI and FSF as GPL-compatible.
+        http://opensource.org/licenses/isc-license.txt
+
+    Copyright (c) 2012, Noah Spurrier <noah@noah.org>
+    PERMISSION TO USE, COPY, MODIFY, AND/OR DISTRIBUTE THIS SOFTWARE FOR ANY
+    PURPOSE WITH OR WITHOUT FEE IS HEREBY GRANTED, PROVIDED THAT THE ABOVE
+    COPYRIGHT NOTICE AND THIS PERMISSION NOTICE APPEAR IN ALL COPIES.
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+'''
+import time
+import unittest
+from ptyprocess import PtyProcess
+
+class WaitOnTerminated(unittest.TestCase):
+
+    def test_wait_true(self):
+        child = PtyProcess.spawn(['/bin/true'])
+        # Wait so we're reasonable sure /bin/true has terminated
+        time.sleep(0.2)
+        exitstatus = child.wait()
+        assert exitstatus == 0
+
+    def test_wait_false(self):
+        child = PtyProcess.spawn(['/bin/false'])
+        time.sleep(0.2)
+        exitstatus = child.wait()
+        assert exitstatus == 1
+
+if __name__ == '__main__':
+    unittest.main()
+
+suite = unittest.makeSuite(WaitOnTerminated,'test')

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,43 +1,33 @@
-#!/usr/bin/env python
-'''
-PEXPECT LICENSE
-
-    This license is approved by the OSI and FSF as GPL-compatible.
-        http://opensource.org/licenses/isc-license.txt
-
-    Copyright (c) 2012, Noah Spurrier <noah@noah.org>
-    PERMISSION TO USE, COPY, MODIFY, AND/OR DISTRIBUTE THIS SOFTWARE FOR ANY
-    PURPOSE WITH OR WITHOUT FEE IS HEREBY GRANTED, PROVIDED THAT THE ABOVE
-    COPYRIGHT NOTICE AND THIS PERMISSION NOTICE APPEAR IN ALL COPIES.
-    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-'''
+""" Test cases for PtyProcess.wait method. """
 import time
 import unittest
 from ptyprocess import PtyProcess
+from ptyprocess.ptyprocess import which
 
-class WaitOnTerminated(unittest.TestCase):
 
-    def test_wait_true(self):
-        child = PtyProcess.spawn(['/bin/true'])
+class TestWaitAfterTermination(unittest.TestCase):
+    """Various test cases for PtyProcess.wait()"""
+
+    def test_wait_true_shortproc(self):
+        """Ensure correct (True) wait status for short-lived processes."""
+        child = PtyProcess.spawn([which('true')])
         # Wait so we're reasonable sure /bin/true has terminated
         time.sleep(0.2)
-        exitstatus = child.wait()
-        assert exitstatus == 0
+        self.assertEqual(child.wait(), 0)
 
-    def test_wait_false(self):
-        child = PtyProcess.spawn(['/bin/false'])
+    def test_wait_false_shortproc(self):
+        """Ensure correct (False) wait status for short-lived processes."""
+        child = PtyProcess.spawn([which('false')])
+        # Wait so we're reasonable sure /bin/false has terminated
         time.sleep(0.2)
-        exitstatus = child.wait()
-        assert exitstatus == 1
+        self.assertEqual(child.wait(), 1)
 
-if __name__ == '__main__':
-    unittest.main()
-
-suite = unittest.makeSuite(WaitOnTerminated,'test')
+    def test_wait_twice_longproc(self):
+        """Ensure correct wait status when called twice."""
+        # previous versions of ptyprocess raises PtyProcessError when
+        # wait was called more than once with "Cannot wait for dead child
+        # process.".  No longer true since v0.5.
+        child = PtyProcess.spawn([which('sleep'), '1'])
+        # this call to wait() will block for 1s
+        for count in range(2):
+            self.assertEqual(child.wait(), 0, count)


### PR DESCRIPTION
This is a minor refactor of @reynir's kind contribution of PR #14. Summary:

- It is no longer an exception to call wait() on a "dead process", or to call it multiple times.
- "/bin/true" and false are actually located in "/usr/bin" on OSX, use ``which()`` to accommodate.
- Add one more test case for calling wait() multiple times on a longer-lived process.