### PR TITLE
bugfix: waitnoecho() refers to missing self.timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ python:
   - "3.3"
   - "3.4"
 # command to run tests
-script: py.test
+script: py.test --verbose --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ python:
   - "3.4"
 # command to run tests
 script: py.test --verbose --verbose
+sudo: False

--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -426,6 +426,9 @@ class PtyProcess(object):
             p.sendline(mypassword)
 
         If timeout==None then this method to block until ECHO flag is False.
+
+        .. note:: all waiting output must be :meth:`~.read` before the ECHO
+           mode of the pty may be determined.
         '''
 
         if timeout is not None:

--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -412,7 +412,7 @@ class PtyProcess(object):
 
         return os.isatty(self.fd)
 
-    def waitnoecho(self, timeout=-1):
+    def waitnoecho(self, timeout=None):
         '''This waits until the terminal ECHO flag is set False. This returns
         True if the echo mode is off. This returns False if the ECHO flag was
         not set False before the timeout. This can be used to detect when the
@@ -425,12 +425,9 @@ class PtyProcess(object):
             p.waitnoecho()
             p.sendline(mypassword)
 
-        If timeout==-1 then this method will use the value in self.timeout.
         If timeout==None then this method to block until ECHO flag is False.
         '''
 
-        if timeout == -1:
-            timeout = self.timeout
         if timeout is not None:
             end_time = time.time() + timeout
         while True:

--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -426,9 +426,6 @@ class PtyProcess(object):
             p.sendline(mypassword)
 
         If timeout==None then this method to block until ECHO flag is False.
-
-        .. note:: all waiting output must be :meth:`~.read` before the ECHO
-           mode of the pty may be determined.
         '''
 
         if timeout is not None:

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -41,7 +41,6 @@ class PtyEchoTestCase(unittest.TestCase):
         inp = b''
         while not inp == b'IN: ':
              inp = att_sh.read().strip(b'\r\n')
-             print(inp)
 
         # we use stty(1) to set echo. By doing so, we can be assured that
         # waitnoecho() will return True even after a short duration (and after
@@ -49,7 +48,6 @@ class PtyEchoTestCase(unittest.TestCase):
         att_sh.write(b'stty echo\n')
         while not inp == b'IN: ':
              inp = att_sh.read().strip('\r\n')
-             print(inp)
         assert att_sh.waitnoecho(timeout=3) == False
         assert att_sh.getecho() == False
 

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -24,33 +24,10 @@ class PtyEchoTestCase(unittest.TestCase):
 
     def test_waitnoecho_timeout(self):
         """Ensure waitnoecho() with timeout will return when using stty to unset echo."""
-        att_sh = PtyProcess.spawn(['sh'], echo=True)
-        # make a prompt we can expect,
-        time.sleep(1)
-        assert att_sh.getecho() == True
-        assert att_sh.waitnoecho(timeout=1) == False
-        att_sh.write(b'export PS1="IN: "\n')
-
-        # we must exhaust all awaiting input.  The terminal attributes made by
-        # setecho() are not understood by getecho() until all awaiting
-        # output is read, irregardless of the TCSANOW attribute we use, it is
-        # not reflected until this is done.
-        #
-        # Furthermore, with stdout line-buffered, we can expect .read() to
-        # return full lines.
-        inp = b''
-        while not inp == b'IN: ':
-             inp = att_sh.read().strip(b'\r\n')
-
-        # we use stty(1) to set echo. By doing so, we can be assured that
-        # waitnoecho() will return True even after a short duration (and after
-        # all of our output has been read.)
-        att_sh.write(b'stty echo\n')
-        while not inp == b'IN: ':
-             inp = att_sh.read().strip('\r\n')
-        assert att_sh.waitnoecho(timeout=3) == False
-        assert att_sh.getecho() == False
-
-        att_sh.write(b'exit 0\n')
-        self._read_until_eof(att_sh)
-        assert att_sh.wait() == 0
+        cat = PtyProcess.spawn(['cat'], echo=True)
+        assert cat.waitnoecho(timeout=1) == False
+        assert cat.echo == True
+        assert cat.getecho() == True
+        cat.sendeof()
+        self._read_until_eof(cat)
+        assert cat.wait() == 0

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -37,16 +37,16 @@ class PtyEchoTestCase(unittest.TestCase):
         #
         # Furthermore, with stdout line-buffered, we can expect .read() to
         # return full lines.
-        inp = u''
-        while not inp == 'IN: ':
-             inp = att_sh.read().strip('\r\n')
+        inp = b''
+        while not inp == b'IN: ':
+             inp = att_sh.read().strip(b'\r\n')
              print(inp)
 
         # we use stty(1) to set echo. By doing so, we can be assured that
         # waitnoecho() will return True even after a short duration (and after
         # all of our output has been read.)
         att_sh.write(b'stty echo\n')
-        while not inp == 'IN: ':
+        while not inp == b'IN: ':
              inp = att_sh.read().strip('\r\n')
              print(inp)
         assert att_sh.waitnoecho(timeout=3) == True

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -28,6 +28,7 @@ class PtyEchoTestCase(unittest.TestCase):
         # make a prompt we can expect,
         time.sleep(1)
         assert att_sh.getecho() == True
+        assert att_sh.waitnoecho(timeout=1) == False
         att_sh.write(b'export PS1="IN: "\n')
 
         # we must exhaust all awaiting input.  The terminal attributes made by
@@ -49,7 +50,7 @@ class PtyEchoTestCase(unittest.TestCase):
         while not inp == b'IN: ':
              inp = att_sh.read().strip('\r\n')
              print(inp)
-        assert att_sh.waitnoecho(timeout=3) == True
+        assert att_sh.waitnoecho(timeout=3) == False
         assert att_sh.getecho() == False
 
         att_sh.write(b'exit 0\n')

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -1,0 +1,16 @@
+import time
+import unittest
+from ptyprocess import PtyProcess
+
+class PtyEchoTestCase(unittest.TestCase):
+    def test_waitnoecho_forever(self):
+        """Ensure waitnoecho() with no timeout will return when echo=False."""
+        cat = PtyProcess.spawn(['cat'], echo=False)
+        assert cat.waitnoecho() == True
+
+    def test_waitnoecho_timeout(self):
+        """Ensure waitnoecho() with timeout will return when using stty to unset echo."""
+        att_sh = PtyProcess.spawn(['sh'], echo=True)
+        time.sleep(1)
+        att_sh.write('stty echo\n')
+        assert att_sh.waitnoecho(timeout=3) == True

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -3,14 +3,55 @@ import unittest
 from ptyprocess import PtyProcess
 
 class PtyEchoTestCase(unittest.TestCase):
+
+    def _read_until_eof(self, proc):
+        """Read away all output on ``proc`` until EOF."""
+        while True:
+            try:
+                proc.read()
+            except EOFError:
+                return
+
     def test_waitnoecho_forever(self):
         """Ensure waitnoecho() with no timeout will return when echo=False."""
         cat = PtyProcess.spawn(['cat'], echo=False)
         assert cat.waitnoecho() == True
+        assert cat.echo == False
+        assert cat.getecho() == False
+        cat.sendeof()
+        self._read_until_eof(cat)
+        assert cat.wait() == 0
 
     def test_waitnoecho_timeout(self):
         """Ensure waitnoecho() with timeout will return when using stty to unset echo."""
         att_sh = PtyProcess.spawn(['sh'], echo=True)
+        # make a prompt we can expect,
         time.sleep(1)
-        att_sh.write('stty echo\n')
+        assert att_sh.getecho() == True
+        att_sh.write(b'export PS1="IN: "\n')
+
+        # we must exhaust all awaiting input.  The terminal attributes made by
+        # setecho() are not understood by getecho() until all awaiting
+        # output is read, irregardless of the TCSANOW attribute we use, it is
+        # not reflected until this is done.
+        #
+        # Furthermore, with stdout line-buffered, we can expect .read() to
+        # return full lines.
+        inp = u''
+        while not inp == 'IN: ':
+             inp = att_sh.read().strip('\r\n')
+             print(inp)
+
+        # we use stty(1) to set echo. By doing so, we can be assured that
+        # waitnoecho() will return True even after a short duration (and after
+        # all of our output has been read.)
+        att_sh.write(b'stty echo\n')
+        while not inp == 'IN: ':
+             inp = att_sh.read().strip('\r\n')
+             print(inp)
         assert att_sh.waitnoecho(timeout=3) == True
+        assert att_sh.getecho() == False
+
+        att_sh.write(b'exit 0\n')
+        self._read_until_eof(att_sh)
+        assert att_sh.wait() == 0


### PR DESCRIPTION
The second test fails on FreeBSD, however. Still investigating. Found this bug in the meantime.