### PR TITLE
FreeBSD /bin/sh test workaround, simple "call and response" test using bc(1)

### DIFF
--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -28,8 +28,6 @@ _is_solaris = (
     _platform.startswith('solaris') or
     _platform.startswith('sunos'))
 
-_is_irix = _platform.startswith('irix')
-
 if _is_solaris:
     use_native_pty_fork = False
     from . import _fork_pty

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -41,7 +41,6 @@ class PtyEchoTestCase(unittest.TestCase):
         inp = b''
         while not inp == b'IN: ':
              inp = att_sh.read().strip(b'\r\n')
-             print(inp)
 
         # we use stty(1) to set echo. By doing so, we can be assured that
         # waitnoecho() will return True even after a short duration (and after
@@ -49,7 +48,6 @@ class PtyEchoTestCase(unittest.TestCase):
         att_sh.write(b'stty echo\n')
         while not inp == b'IN: ':
              inp = att_sh.read().strip('\r\n')
-             print(inp)
         assert att_sh.waitnoecho(timeout=3) == False
         assert att_sh.getecho() == False
 

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -28,7 +28,7 @@ class PtyEchoTestCase(unittest.TestCase):
         # make a prompt we can expect,
         time.sleep(1)
         assert att_sh.getecho() == True
-        att_sh.write('export PS1="IN: "\n')
+        att_sh.write(b'export PS1="IN: "\n')
 
         # we must exhaust all awaiting input.  The terminal attributes made by
         # setecho() are not understood by getecho() until all awaiting
@@ -45,13 +45,13 @@ class PtyEchoTestCase(unittest.TestCase):
         # we use stty(1) to set echo. By doing so, we can be assured that
         # waitnoecho() will return True even after a short duration (and after
         # all of our output has been read.)
-        att_sh.write('stty echo\n')
+        att_sh.write(b'stty echo\n')
         while not inp == 'IN: ':
              inp = att_sh.read().strip('\r\n')
              print(inp)
         assert att_sh.waitnoecho(timeout=3) == True
         assert att_sh.getecho() == False
 
-        att_sh.write('exit 0\n')
+        att_sh.write(b'exit 0\n')
         self._read_until_eof(att_sh)
         assert att_sh.wait() == 0

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -28,6 +28,7 @@ class PtyEchoTestCase(unittest.TestCase):
         # make a prompt we can expect,
         time.sleep(1)
         assert att_sh.getecho() == True
+        assert att_sh.waitnoecho(timeout=1) == False
         att_sh.write(b'export PS1="IN: "\n')
 
         # we must exhaust all awaiting input.  The terminal attributes made by
@@ -49,7 +50,7 @@ class PtyEchoTestCase(unittest.TestCase):
         while not inp == b'IN: ':
              inp = att_sh.read().strip('\r\n')
              print(inp)
-        assert att_sh.waitnoecho(timeout=3) == True
+        assert att_sh.waitnoecho(timeout=3) == False
         assert att_sh.getecho() == False
 
         att_sh.write(b'exit 0\n')

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -3,14 +3,55 @@ import unittest
 from ptyprocess import PtyProcess
 
 class PtyEchoTestCase(unittest.TestCase):
+
+    def _read_until_eof(self, proc):
+        """Read away all output on ``proc`` until EOF."""
+        while True:
+            try:
+                proc.read()
+            except EOFError:
+                return
+
     def test_waitnoecho_forever(self):
         """Ensure waitnoecho() with no timeout will return when echo=False."""
         cat = PtyProcess.spawn(['cat'], echo=False)
         assert cat.waitnoecho() == True
+        assert cat.echo == False
+        assert cat.getecho() == False
+        cat.sendeof()
+        self._read_until_eof(cat)
+        assert cat.wait() == 0
 
     def test_waitnoecho_timeout(self):
         """Ensure waitnoecho() with timeout will return when using stty to unset echo."""
         att_sh = PtyProcess.spawn(['sh'], echo=True)
+        # make a prompt we can expect,
         time.sleep(1)
+        assert att_sh.getecho() == True
+        att_sh.write('export PS1="IN: "\n')
+
+        # we must exhaust all awaiting input.  The terminal attributes made by
+        # setecho() are not understood by getecho() until all awaiting
+        # output is read, irregardless of the TCSANOW attribute we use, it is
+        # not reflected until this is done.
+        #
+        # Furthermore, with stdout line-buffered, we can expect .read() to
+        # return full lines.
+        inp = u''
+        while not inp == 'IN: ':
+             inp = att_sh.read().strip('\r\n')
+             print(inp)
+
+        # we use stty(1) to set echo. By doing so, we can be assured that
+        # waitnoecho() will return True even after a short duration (and after
+        # all of our output has been read.)
         att_sh.write('stty echo\n')
+        while not inp == 'IN: ':
+             inp = att_sh.read().strip('\r\n')
+             print(inp)
         assert att_sh.waitnoecho(timeout=3) == True
+        assert att_sh.getecho() == False
+
+        att_sh.write('exit 0\n')
+        self._read_until_eof(att_sh)
+        assert att_sh.wait() == 0

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -1,5 +1,6 @@
 import time
 import unittest
+from ptyprocess.ptyprocess import _is_solaris
 from ptyprocess import PtyProcess
 
 class PtyEchoTestCase(unittest.TestCase):
@@ -12,6 +13,7 @@ class PtyEchoTestCase(unittest.TestCase):
             except EOFError:
                 return
 
+    @unittest.skipIf(_is_solaris, "waitnoecho cannot be called on this platform.")
     def test_waitnoecho_forever(self):
         """Ensure waitnoecho() with no timeout will return when echo=False."""
         cat = PtyProcess.spawn(['cat'], echo=False)
@@ -22,6 +24,7 @@ class PtyEchoTestCase(unittest.TestCase):
         self._read_until_eof(cat)
         assert cat.wait() == 0
 
+    @unittest.skipIf(_is_solaris, "waitnoecho cannot be called on this platform.")
     def test_waitnoecho_timeout(self):
         """Ensure waitnoecho() with timeout will return when using stty to unset echo."""
         cat = PtyProcess.spawn(['cat'], echo=True)

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -56,7 +56,7 @@ class PtyTestCase(unittest.TestCase):
         PtyProcess.spawn(['true'])
 
     def _interactive_repl_unicode(self, echo):
-        """Test Call and response in proc.readline(), echo OFF."""
+        """Test Call and response with echo ON/OFF."""
         # given,
         bc = PtyProcessUnicode.spawn(['bc'], echo=echo)
         given_input = u'2+2+2+2+2+2+2+2+2+2+2+2+2+2+2+2+2+2+2+2\n'
@@ -97,7 +97,7 @@ class PtyTestCase(unittest.TestCase):
         # validate EOF on read
         while True:
             try:
-                bc.readline()
+                bc.read()
             except EOFError:
                 break
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -2,43 +2,55 @@ import os
 import time
 import unittest
 from ptyprocess import PtyProcess, PtyProcessUnicode
+from ptyprocess.ptyprocess import which
 
 class PtyTestCase(unittest.TestCase):
-    def test_spawn_sh(self):
-        env = os.environ.copy()
-        env['FOO'] = 'rebar'
-        p = PtyProcess.spawn(['sh'], env=env)
-        p.read()
-        p.write(b'echo $FOO\n')
-        time.sleep(0.1)
-        response = p.read()
-        assert b'rebar' in response
-        
-        p.sendeof()
-        p.readline()
-        
-        with self.assertRaises(EOFError):
-            p.read()
+    def setUp(self):
+        self.cmd = u'echo $ENV_KEY; exit 0\n'
+        self.env = os.environ.copy()
+        self.env_key = u'ENV_KEY'
+        self.env_value = u'env_value'
+        self.env[self.env_key] = self.env_value
 
-    def test_spawn_unicode_sh(self):
-        env = os.environ.copy()
-        env['FOO'] = 'rebar'
-        p = PtyProcessUnicode.spawn(['sh'], env=env)
-        p.read()
-        p.write(u'echo $FOO\n')
-        time.sleep(0.1)
-        response = p.read()
-        assert u'rebar' in response
-        
-        p.sendeof()
-        p.readline()
-        
+    def _spawn_sh(self, cmd, outp):
+        # given,
+        p = PtyProcess.spawn(['sh'], env=self.env)
+        p.write(cmd)
+
+        # exercise,
+        while True:
+            try:
+                outp += p.read()
+            except EOFError:
+                break
+
+        # verify, read after EOF keeps throwing EOF
         with self.assertRaises(EOFError):
             p.read()
+        with self.assertRaises(EOFError):
+            p.readline()
+
+        # verify, input is echo to output
+        assert self.cmd.strip() in outp
+
+        # result of echo $ENV_KEY in output
+        assert self.env_value in outp
+
+        # exit succesfully (exit 0)
+        assert p.wait() == 0
+
+
+    def test_spawn_sh(self):
+        outp = b''
+        self._spawn_sh(self.cmd.encode('ascii'), outp)
+
+    def test_spawn_sh_unicode(self):
+        outp = u''
+        self._spawn_sh(self.cmd, outp)
 
     def test_quick_spawn(self):
         """Spawn a very short-lived process."""
         # so far only reproducable on Solaris 11, spawning a process
         # that exits very quickly raised an exception at 'inst.setwinsize',
         # because the pty file descriptor was quickly lost after exec().
-        PtyProcess.spawn(['/bin/true'])
+        PtyProcess.spawn(['true'])

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -19,7 +19,7 @@ class TestWaitAfterTermination(unittest.TestCase):
         child = PtyProcess.spawn(['false'])
         # Wait so we're reasonable sure /bin/false has terminated
         time.sleep(0.2)
-        self.assertEqual(child.wait(), 1)
+        self.assertNotEqual(child.wait(), 0)
 
     def test_wait_twice_longproc(self):
         """Ensure correct wait status when called twice."""

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -2,7 +2,6 @@
 import time
 import unittest
 from ptyprocess import PtyProcess
-from ptyprocess.ptyprocess import which
 
 
 class TestWaitAfterTermination(unittest.TestCase):
@@ -10,14 +9,14 @@ class TestWaitAfterTermination(unittest.TestCase):
 
     def test_wait_true_shortproc(self):
         """Ensure correct (True) wait status for short-lived processes."""
-        child = PtyProcess.spawn([which('true')])
+        child = PtyProcess.spawn(['true'])
         # Wait so we're reasonable sure /bin/true has terminated
         time.sleep(0.2)
         self.assertEqual(child.wait(), 0)
 
     def test_wait_false_shortproc(self):
         """Ensure correct (False) wait status for short-lived processes."""
-        child = PtyProcess.spawn([which('false')])
+        child = PtyProcess.spawn(['false'])
         # Wait so we're reasonable sure /bin/false has terminated
         time.sleep(0.2)
         self.assertEqual(child.wait(), 1)
@@ -27,7 +26,7 @@ class TestWaitAfterTermination(unittest.TestCase):
         # previous versions of ptyprocess raises PtyProcessError when
         # wait was called more than once with "Cannot wait for dead child
         # process.".  No longer true since v0.5.
-        child = PtyProcess.spawn([which('sleep'), '1'])
+        child = PtyProcess.spawn(['sleep', '1'])
         # this call to wait() will block for 1s
         for count in range(2):
             self.assertEqual(child.wait(), 0, count)


### PR DESCRIPTION
- Workaround freebsd AT&T shell in test.

  - There is something I am not able to understand about /bin/sh on freebsd: This is actually some kind of "second output of input echo" that occurs only with the AT&T-compatible /bin/sh on FreeBSD, and intermittently (a modified version of the test runs forever on OSX and Linux). Full analysis in https://github.com/pexpect/ptyprocess/issues/12#issuecomment-96443761

  - The workaround is to gather **all** output to a single string, instead of individual line-by-line reads.

- Made only a slightly better "call and response/repl" test, but I ran into a lot of blockers.

  - It seems the non-gnu bc(1) (anything but Linux) somehow echos input to output, even when ``echo=False``. I thoroughly tested the getecho/setecho/waitnoecho family of functions (and discovered PR #19 along the way). If I run "stty -echo" on bash, then bc, my input is most certainly not written to output.
  - My current theory is that there is a difference between executing bc(1) directly and setting terminal attributes rather than executing a shell, setting terminal attributes, then executing bc(1) from there. I just added a "note:" about not including an assertion for now.

- remove unused ``_is_irix``
- skip ``waitnoecho`` tests on Solaris
- I saw /bin/false return something other than 1.  Once.. just check non-zero status instead. https://teamcity-master.pexpect.org/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=6228#_focus=2040