### PR TITLE
Tested with Python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ from distutils.core import setup
 with open('README.rst') as f:
     readme = f.read()
 
-assert sys.version_info >= (2, 7), (
-    "Only python 2.7 and later is supported by ptyprocess.")
+assert sys.version_info >= (2, 6), (
+    "Only python 2.6 and later is supported by ptyprocess.")
 
 setup(name='ptyprocess',
       version='0.5',

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -1,5 +1,11 @@
 import time
-import unittest
+import sys
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
+
 from ptyprocess.ptyprocess import _is_solaris
 from ptyprocess import PtyProcess
 

--- a/tests/test_invalid_binary.py
+++ b/tests/test_invalid_binary.py
@@ -19,7 +19,13 @@ PEXPECT LICENSE
 
 '''
 import time
-import unittest
+import sys
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
+
 from ptyprocess import PtyProcess, PtyProcessUnicode
 import errno
 import os

--- a/tests/test_preexec_fn.py
+++ b/tests/test_preexec_fn.py
@@ -18,7 +18,13 @@ PEXPECT LICENSE
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 '''
-import unittest
+import sys
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
+
 import shutil
 from ptyprocess import PtyProcess
 import os

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -1,7 +1,13 @@
 import os
 import time
 import select
-import unittest
+import sys
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
+
 from ptyprocess.ptyprocess import which
 from ptyprocess import PtyProcess, PtyProcessUnicode
 

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,6 +1,12 @@
 """ Test cases for PtyProcess.wait method. """
 import time
-import unittest
+import sys
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
+
 from ptyprocess import PtyProcess
 
 


### PR DESCRIPTION
Since pexpect should support 2.6, dependencies also should support 2.6.
