### PR TITLE
fix typo pass -> return

### DIFF
--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -55,7 +55,7 @@ def _make_eof_intr():
     """
     global _EOF, _INTR
     if (_EOF is not None) and (_INTR is not None):
-        pass
+        return
 
     # inherit EOF and INTR definitions from controlling process.
     try:


### PR DESCRIPTION
This fixes what appears to be a typo. It seems the intent is to only initialize the global variables once. If that's the case, the `pass` should be a `return`.