### PR TITLE
Use and prefer os.posix_spawn() when available

### DIFF
--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -36,7 +36,6 @@ _have_posix_spawn = (
     hasattr(os, 'posix_spawn') and
     _platform.startswith("linux"))
 if _have_posix_spawn:
-    print("using posix_spawn")
     _posix_spawn_lock = threading.Lock()
 
 # Solaris uses internal __fork_pty(). All others use pty.fork().


### PR DESCRIPTION
Python 3.8 has added os.posix_spawn(), this changes ptyprocess
to use it when available.

Since os.posix_spawn() completey bypasses os.fork(), pty.fork(),
it avoids problems with logging locks and code needing to be thread-safe.