### PR TITLE
Add **kwargs to PtyProcess.spawn

### DIFF
--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -178,7 +178,7 @@ class PtyProcess(object):
     @classmethod
     def spawn(
             cls, argv, cwd=None, env=None, echo=True, preexec_fn=None,
-            dimensions=(24, 80), pass_fds=()):
+            dimensions=(24, 80), pass_fds=(), **kwargs):
         '''Start the given command in a child process in a pseudo terminal.
 
         This does all the fork/exec type of stuff for a pty, and returns an
@@ -300,7 +300,7 @@ class PtyProcess(object):
                 os._exit(os.EX_OSERR)
 
         # Parent
-        inst = cls(pid, fd)
+        inst = cls(pid, fd, **kwargs)
         
         # Set some informational attributes
         inst.argv = argv

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -57,6 +57,10 @@ class PtyTestCase(unittest.TestCase):
         # because the pty file descriptor was quickly lost after exec().
         PtyProcess.spawn(['true'])
 
+    def test_spawn_unicode_decoding(self):
+        p = PtyProcessUnicode.spawn(['printf', '\\344\\272!'], codec_errors='backslashreplace')
+        assert p.read() == '\\xe4\\xba!'
+
     def _interactive_repl_unicode(self, echo):
         """Test Call and response with echo ON/OFF."""
         # given,


### PR DESCRIPTION
The `PtyProcessUnicode` class accept keywords argument like `encoding` and `codec_errors`. However, it seems not easy to set these argument just using `PtyProcess.spawn`.

I think we could add a `**kwargs` to `spawn` and create the class instance using `cls(pid, fd, **kwargs)`. It will be neat and improve extensibility.