### PR TITLE
Read error in PtyTestCase::test_pass_fds

### DIFF
--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -142,6 +142,7 @@ class PtyTestCase(unittest.TestCase):
                                   '-c',
                                   'printf bye >&{}'.format(temp_file_fd)],
                                  echo=True)
+            p.read() # Read error off child to allow it to terminate nicely
             p.wait()
             assert p.status != 0
 


### PR DESCRIPTION
Without this on macOS the child process becomes a zombie, because parent never reaps it after exit.