### PR TITLE
Add support for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,20 +2,25 @@ name: Test
 
 on: [push, pull_request]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", 2.7]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", 2.7]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python ${{ matrix.python-version }} / ${{ matrix.os }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 2.7]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", 2.7]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python ${{ matrix.python-version }} / ${{ matrix.os }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)


---

Also maybe time to drop EOL Python <= 3.6?

Here's the pip installs for ptyprocess from PyPI for October 2022:

| category | percent |  downloads |
|:---------|--------:|-----------:|
| 3.7      |  29.33% |  7,840,362 |
| 3.8      |  23.53% |  6,289,131 |
| 3.9      |  18.12% |  4,843,521 |
| 3.10     |  12.51% |  3,344,769 |
| 3.6      |   7.83% |  2,092,917 |
| null     |   6.31% |  1,687,690 |
| 2.7      |   1.73% |    462,046 |
| 3.11     |   0.42% |    111,185 |
| 3.5      |   0.17% |     45,885 |
| 3.4      |   0.05% |     13,545 |
| 3.12     |   0.00% |        143 |
| 3.3      |   0.00% |         69 |
| 3.2      |   0.00% |          6 |
| Total    |         | 26,731,269 |

Source: `pip install -U pypistats && pypistats python_minor ptyprocess --last-month`