### PR TITLE
Remove unittest.makeSuite, gone from Python 3.13

### DIFF
--- a/tests/test_invalid_binary.py
+++ b/tests/test_invalid_binary.py
@@ -69,6 +69,3 @@ class InvalidBinaryChars(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
-suite = unittest.makeSuite(InvalidBinaryChars,'test')
-


### PR DESCRIPTION
See https://docs.python.org/3.13/whatsnew/3.13.html

"""
Removed the following unittest functions, deprecated in Python 3.11:

    unittest.findTestCases()
    unittest.makeSuite()
    unittest.getTestCaseNames()
"""

The removed call does not seem to have any effect when the file is executed directly, run trough unittest discover or pytest.