### PR TITLE
Bump required Python version to 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", 2.7]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ author = "Thomas Kluyver"
 author-email = "thomas@kluyver.me.uk"
 home-page = "https://github.com/pexpect/ptyprocess"
 description-file = "README.rst"
+requires-python = ">=3.7"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -17,7 +18,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
     "Topic :: Terminals"
 ]


### PR DESCRIPTION
As discussed in #75.

It wouldn't be difficult to keep some older Python versions supported if there's a need - ptyprocess isn't changing much at present. But I don't know of a need for that, and testing on outdated Python versions is only going to get more awkward.