### PR TITLE
Fix: Fallback to internal PTY setup when os.login_tty is unavailable (improves AIX and Solaris support)

### DIFF
--- a/ptyprocess/_fork_pty.py
+++ b/ptyprocess/_fork_pty.py
@@ -1,4 +1,10 @@
-"""Substitute for the forkpty system call, to support Solaris.
+"""
+Provides an alternative PTY forking mechanism.
+
+This implementation serves as a substitute for Python's standard `pty.fork()`
+functionality, especially on platforms where `os.login_tty()` is unavailable
+in the Python build (e.g., some AIX configurations) or where the standard
+implementation is problematic (e.g., historically on Solaris).
 """
 import os
 import errno
@@ -7,17 +13,26 @@ from pty import (STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO, CHILD)
 from .util import PtyProcessError
 
 def fork_pty():
-    '''This implements a substitute for the forkpty system call. This
-    should be more portable than the pty.fork() function. Specifically,
-    this should work on Solaris.
+    '''This implements a substitute for the functionality of pty.fork(),
+    aiming for greater portability, especially on systems where Python's
+    os.login_tty() is unavailable or pty.fork() is problematic.
 
-    Modified 10.06.05 by Geoff Marshall: Implemented __fork_pty() method to
-    resolve the issue with Python's pty.fork() not supporting Solaris,
-    particularly ssh. Based on patch to posixmodule.c authored by Noah
-    Spurrier::
+    It is designed to work on:
+    - Solaris systems (addressing historical issues with Python's pty.fork()).
+    - AIX systems where os.login_tty() might not be compiled into Python.
+    - Other Unix-like systems that might lack a functional os.login_tty().
 
+    The core logic for establishing a new session and making the pseudo-terminal
+    the controlling terminal is handled herein, similar to the operations
+    typically performed by login_tty().
+
+    Historical Context (Original Solaris solution by Geoff Marshall, 10.06.05):
+    The method was initially implemented to resolve issues with Python's
+    pty.fork() on Solaris, particularly for applications like ssh. It was
+    inspired by a patch to Python's posixmodule.c authored by Noah Spurrier:
         http://mail.python.org/pipermail/python-dev/2003-May/035281.html
-
+    This approach has been generalized to cover other platforms or scenarios
+    where os.login_tty() is not available.
     '''
 
     parent_fd, child_fd = os.openpty()

--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -32,6 +32,8 @@ try:
     from os import login_tty
 except ImportError:
     _no_login_tty = True
+else:
+    _no_login_tty = False
 
 if _is_solaris or _no_login_tty:
     use_native_pty_fork = False

--- a/ptyprocess/ptyprocess.py
+++ b/ptyprocess/ptyprocess.py
@@ -28,7 +28,12 @@ _is_solaris = (
     _platform.startswith('solaris') or
     _platform.startswith('sunos'))
 
-if _is_solaris:
+try:
+    from os import login_tty
+except ImportError:
+    _no_login_tty = True
+
+if _is_solaris or _no_login_tty:
     use_native_pty_fork = False
     from . import _fork_pty
 else:


### PR DESCRIPTION
## Problem

Currently, `pexpect` (via `ptyprocess`) relies on Python's standard `pty.fork()`, which, s[ince Python3.12](https://github.com/python/cpython/commit/244d4cd9d22d73fb3c0938937c4f435bd68f32d4). in turn depends on `os.login_tty()` to correctly set up the child process's controlling terminal and session.

On some Python builds, particularly observed on AIX 7.3 (but potentially applicable to other Unix-like systems or minimal builds), `os.login_tty` may not be compiled into the `os` module. This occurs if the underlying C `login_tty()` function is not detected during Python's `./configure` stage (e.g., on AIX, `login_tty` isn't found in `libc` or a discoverable `libutil`).

When `os.login_tty` is missing, any attempt to use `pty.fork()` (and thus `pexpect.spawn()` in its default mode) results in an `AttributeError`, rendering `pexpect` unusable on these platforms.

## Solution

This pull request modifies `ptyprocess` to gracefully handle situations where `os.login_tty` is not available. The approach is:

1.  **Feature Detection:** At import time (or an appropriate initialization point), `ptyprocess` now checks for the availability of `os.login_tty`.
2.  **Fallback Mechanism:** If `os.login_tty` is found to be unavailable (or if the platform is Solaris, continuing the existing specific handling for it), `ptyprocess` will now utilize its internal PTY forking logic (referred to as `_fork_pty` in previous discussions, adapted from the robust mechanism historically used for Solaris).

This ensures that a proper PTY environment is established for the child process even without `os.login_tty`.

## Why this approach?

* **Robustness & Portability:** Checking for the `os.login_tty` feature directly is more robust than hardcoding platform-specific checks (e.g., just for `'aix'`). This solution will benefit any platform or Python build where `os.login_tty` might be missing.
* **Consistency:** It extends and aligns with the existing pattern in `ptyprocess` for handling Solaris PTY issues.
* **Effective:** This change allows `pexpect` to function correctly on affected systems.

## Affected Platforms

* **AIX 7.3:** Resolves `pexpect` failures when Python is built without `os.login_tty`.
* **Solaris:** Continues to use the established robust internal PTY forking mechanism.
* **Other Unix-like Systems:** May benefit if they encounter Python builds missing `os.login_tty`.

## Testing

* Successfully tested on AIX 7.3 with Python 3.13 and 3.12 compiled from source, where `os.login_tty` was confirmed to be unavailable.

## Background

The internal PTY setup logic adapted here has its roots in the established Solaris workaround within `ptyprocess`, which itself was inspired by earlier patches to Python's `posixmodule.c` (e.g., by Noah Spurrier) to manually implement `login_tty` functionality when the C system call wasn't available or reliable.

---